### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,5 @@
+name        := "boost"
+description := "Boost is a set of libraries for the C++ programming language that provides support for tasks and structures such as linear algebra, pseudorandom number generation, multithreading, image processing, regular expressions, and unit testing."
+website     := "https://www.boost.org/"
+version     := 1.71.0 sha256:96b34f7468f26a141f6020efb813f1a2f3dfb9797ecf76a7d7cbd843cc95f5bd https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz
+license     := "BSL-1.0"


### PR DESCRIPTION
Introduce `Library.uk`

This new file represents the first step towards proper versioning support of
external microlibrary in Unikraft.  The file itself acts as mechanism for
holding metadata-only values about the microlibrary.  This metadata is designed
to be compatible with GNU Make whilst simultaneously being human-readable and
readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions.
In a later step, once relevant integrations have been made to Unikrat's core
build system and to relevant tools such as KraftKit, the user will be able to
see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk,
Config.uk, but also includes new information such as SPDX License identifier.

Signed-off-by: Alexander Jung <alex@unikraft.io>
